### PR TITLE
Add -NoProfile to launched pwsh consoles

### DIFF
--- a/PowerShell.MCP.Proxy/Services/PowerShellProcessManager.cs
+++ b/PowerShell.MCP.Proxy/Services/PowerShellProcessManager.cs
@@ -170,6 +170,8 @@ public class PowerShellProcessManager
 /// </summary>
 internal static class PwshLauncherShared
 {
+    internal const string NoProfileArgument = "-NoProfile";
+
     // Force the new console's active code page to UTF-8 BEFORE PSReadLine
     // imports. On Japanese / Chinese / Korean Windows the system code page
     // is 932 / 936 / 949, and CREATE_NEW_CONSOLE inherits that as the
@@ -208,6 +210,18 @@ internal static class PwshLauncherShared
         var core = $"{EncodingPrelude}{setLocation}$global:PowerShellMCPProxyPid = {proxyPid}; $global:PowerShellMCPAgentId = '{escapedAgentId}'; {ModuleCaseFix}Import-Module PowerShell.MCP -Force; Remove-Module PSReadLine -ErrorAction SilentlyContinue";
         return string.IsNullOrEmpty(startupCommands) ? core : $"{core}; {startupCommands}";
     }
+
+    internal static string BuildWindowsCommandLine(string command) =>
+        $"pwsh.exe {NoProfileArgument} -NoExit -Command \"{command}\"";
+
+    internal static string BuildMacOSDoScriptCommand(string tempFile) =>
+        $"pwsh {NoProfileArgument} -NoExit -File '{tempFile}'";
+
+    internal static string BuildLinuxPwshCommand(string encodedCommand) =>
+        $"exec pwsh {NoProfileArgument} -NoExit -EncodedCommand {encodedCommand}";
+
+    internal static string[] BuildHeadlessPwshArguments(string initCommand) =>
+        [NoProfileArgument, "-NoExit", "-Command", initCommand];
 }
 
 /// <summary>
@@ -308,7 +322,7 @@ public static class PwshLauncherWindows
             {
                 command = $"{PwshLauncherShared.EncodingPrelude}$global:PowerShellMCPProxyPid = {proxyPid}; $global:PowerShellMCPAgentId = '{agentId}'; Import-Module PowerShell.MCP -Force; Import-Module PSReadLine";
             }
-            string commandLine = $"pwsh.exe -NoExit -Command \"{command}\"";
+            string commandLine = PwshLauncherShared.BuildWindowsCommandLine(command);
 
             bool ok = CreateProcessW(
                 null,
@@ -381,7 +395,7 @@ public static class PwshLauncherMacOS
         {
             process.StandardInput.WriteLine("tell application \"Terminal\"");
             process.StandardInput.WriteLine("    activate");
-            process.StandardInput.WriteLine($"    do script \"pwsh -NoExit -File '{tempFile}'\"");
+            process.StandardInput.WriteLine($"    do script \"{PwshLauncherShared.BuildMacOSDoScriptCommand(tempFile)}\"");
             process.StandardInput.WriteLine("end tell");
             process.StandardInput.Close();
             process.WaitForExit(5000);
@@ -472,7 +486,7 @@ public static class PwshLauncherLinux
 
             // Command to launch pwsh with encoded initialization via login shell
             // exec replaces the shell with pwsh to keep the process tree clean
-            var pwshCommand = $"exec pwsh -NoExit -EncodedCommand {encodedCommand}";
+            var pwshCommand = PwshLauncherShared.BuildLinuxPwshCommand(encodedCommand);
 
             // setsid <terminal> ... <shell> -l -c '<pwshCommand>'
             psi.ArgumentList.Add(terminal);
@@ -565,9 +579,10 @@ public static class PwshLauncherLinux
             RedirectStandardOutput = true,
             RedirectStandardError = true,
         };
-        psi.ArgumentList.Add("-NoExit");
-        psi.ArgumentList.Add("-Command");
-        psi.ArgumentList.Add(initCommand);
+        foreach (var argument in PwshLauncherShared.BuildHeadlessPwshArguments(initCommand))
+        {
+            psi.ArgumentList.Add(argument);
+        }
 
         var process = Process.Start(psi);
         if (process != null)

--- a/Tests/Unit/Proxy/PwshLauncherSharedTests.cs
+++ b/Tests/Unit/Proxy/PwshLauncherSharedTests.cs
@@ -60,4 +60,40 @@ public class PwshLauncherSharedTests
         Assert.True(caseFixIdx >= 0, "case-fix snippet must be present");
         Assert.True(caseFixIdx < importIdx, "case-fix must run before Import-Module");
     }
+
+    [Fact]
+    public void BuildWindowsCommandLine_IncludesNoProfile()
+    {
+        var commandLine = PwshLauncherShared.BuildWindowsCommandLine("Import-Module PowerShell.MCP");
+
+        Assert.Contains("pwsh.exe -NoProfile -NoExit -Command", commandLine);
+    }
+
+    [Fact]
+    public void BuildMacOSDoScriptCommand_IncludesNoProfile()
+    {
+        var command = PwshLauncherShared.BuildMacOSDoScriptCommand("/tmp/pwsh-mcp-init-test.ps1");
+
+        Assert.Equal("pwsh -NoProfile -NoExit -File '/tmp/pwsh-mcp-init-test.ps1'", command);
+    }
+
+    [Fact]
+    public void BuildLinuxPwshCommand_IncludesNoProfile()
+    {
+        var command = PwshLauncherShared.BuildLinuxPwshCommand("encoded");
+
+        Assert.Equal("exec pwsh -NoProfile -NoExit -EncodedCommand encoded", command);
+    }
+
+    [Fact]
+    public void BuildHeadlessPwshArguments_IncludesNoProfileBeforeNoExit()
+    {
+        var arguments = PwshLauncherShared.BuildHeadlessPwshArguments("Import-Module PowerShell.MCP");
+
+        Assert.Equal(4, arguments.Length);
+        Assert.Equal("-NoProfile", arguments[0]);
+        Assert.Equal("-NoExit", arguments[1]);
+        Assert.Equal("-Command", arguments[2]);
+        Assert.Equal("Import-Module PowerShell.MCP", arguments[3]);
+    }
 }


### PR DESCRIPTION
## Summary
- add `-NoProfile` to every `pwsh` launch path used by `start_console`
- route Windows, macOS, Linux terminal, and Linux headless launch arguments through shared helpers
- add unit coverage for the generated launch commands/arguments

## Validation
- `dotnet test Tests/PowerShell.MCP.Tests.csproj --configuration Release --no-restore`
- `dotnet build PowerShell.MCP.sln --configuration Release --no-restore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated PowerShell launch mechanisms across Windows, macOS, and Linux platforms with shared command-line argument builders for improved consistency and maintainability.

* **Tests**
  * Added test cases validating consistent PowerShell launch behavior across Windows, macOS, Linux, and headless execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->